### PR TITLE
Add generic Storage interface to allow for other storages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,21 @@ At the end of the test the notebook fixture will save experiment metadata, the
 inputs, and whatever was passed to ``notebook.record`` to a database. By default,
 this database will be a sqlite database called ``experiments.db``.
 
+To use a different storage you can pass an `Storage` implementent to `mark.experiment`:
+
+.. code-block:: python
+    
+    import pytest
+    from pytest_experiments.store import NdJsonStore
+
+    @pytest.mark.experiment(store=NdJsonStore(file_path="stored-records.ndjson"))
+    @pytest.mark.parameterize("x", [1, 2, 3])  # The inputs; we will run this experiment for x=1, x=2, and x=3
+    def test_my_numerical_method(notebook, x):  # Request the notebook fixture
+        result = my_implementation(x)
+        assert result_is_valid(result)  # our concrete expectations about the result
+        notebook.record(performance=performance_metric(result))  # record the performance
+
+
 A machine learning example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-experiments"
-version = "0.1.1"
+version = "0.1.2"
 description = "A pytest plugin to help developers of research-oriented software projects keep track of the results of their numerical experiments."
 authors = ["Matt Battifarano <matthew.battifarano@gmail.com>"]
 license = "MIT"

--- a/src/pytest_experiments/common.py
+++ b/src/pytest_experiments/common.py
@@ -1,7 +1,14 @@
 """Package tools common across modules."""
 import enum
 import datetime as dt
-from typing import Any
+from typing import Any, Dict, NamedTuple
+
+try:
+    from typing import Protocol
+except:
+    from typing_extensions import Protocol
+
+import pytest
 
 
 class PytestExperimentsError(Exception):
@@ -57,6 +64,20 @@ class ExperimentOutcome(DocumentedEnum):
     error = 4, "The test failed during setup."
     not_reported = 5, "The test outcome was not reported."
 
+
+class ExperimentRecord(NamedTuple):
+    name: str
+    start_time: dt.datetime
+    end_time: dt.datetime
+    outcome: str
+    parameters: Dict[str, Any]
+    data: Dict[str, Any]
+
+class Storage(Protocol):
+
+    def record_experiment(self, record: ExperimentRecord):
+        """ Record an experiment in the storage """
+        raise NotImplementedError
 
 def mark_utc(timestamp: dt.datetime) -> dt.datetime:
     """Mark a UTC timestamp with the UTC timezone.


### PR DESCRIPTION
Thanks for your implementation. I wanted to use an ndjson storage for my use case and changed the code in a way to implement some generic `Storage` protocol.
A different storage can be passed in through the `experiment` marker